### PR TITLE
Fix macOS build step to run for both Apple Silicon and Intel Macs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
 
       # ---------- macOS ----------
       - name: Build with PyInstaller (macOS)
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         shell: bash
         run: |
           pyinstaller \


### PR DESCRIPTION
The build step was only configured for macos-latest, causing the macos-13 (Intel) build to fail. Changed condition from 'matrix.os == macos-latest' to 'startsWith(matrix.os, "macos")' to include both runners.

### Summary

Describe what this PR changes.

### Changes

- [ ] Code improvements
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Verification

Steps to test:

1. Run the app on macOS / Windows.
2. Confirm feature behaves as expected.

### Notes

Include any other context.
