### PR TITLE
Fix Tauri updater: Ensure latest.json generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,4 +69,5 @@ jobs:
           releaseDraft: false
           prerelease: false
           includeUpdaterJson: true
+          updaterJsonPreferNsis: true
           args: --target ${{ matrix.target }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmmloader26",
-  "version": "1.1.0",
+  "version": "1.0.3",
   "description": "A mod manager for Football Manager 2026",
   "type": "module",
   "scripts": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FMMLoader26",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.jalco.fmmloader26",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
- Add updaterJsonPreferNsis flag to prefer NSIS installers for Windows
- Fix version sync between package.json and tauri.conf.json
- Bump version to 1.0.3 for new release with working updater

This fixes the issue where latest.json wasn't being found in releases, which prevented the auto-updater from working correctly.

