### PR TITLE
Fix Tauri updater configuration

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,9 +65,6 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": {
-        "fromEnv": "TAURI_UPDATER_PUBKEY"
-      },
       "endpoints": [
         "https://github.com/justinlevinedotme/FMMLoader-26/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
Remove invalid pubkey object configuration that was causing build failure. Tauri 2.0 automatically uses TAURI_UPDATER_PUBKEY environment variable when set during build, so explicit config is not needed.

Fixes: failed to parse updater plugin configuration: invalid type: map, expected a string
