### PR TITLE
Add privacy policy documentation

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,71 @@
+FMMLoader-26 Privacy Policy
+
+Last updated: November 17, 2025
+
+FMMLoader-26 is an open-source tool for managing Football Manager mods and graphics.
+It is designed to operate locally on the user’s device. The project does not collect, store, or transmit any personal data.
+
+⸻
+
+1. Information We Do Not Collect
+
+FMMLoader-26 does not collect or process:
+- Personal information
+- Usernames, emails, or identifiers
+- System information
+- Analytics or usage data
+- Crash logs or diagnostics
+- IP addresses (we do not log or store them)
+
+The app does not include telemetry, tracking, advertising, or analytics of any kind.
+
+⸻
+
+2. Local-Only Operations
+
+All mod routing, file movements, and graphics installations occur entirely on your device.
+No information is sent to the developer or any third party outside of the services listed below.
+
+⸻
+
+3. Internet Connections
+
+FMMLoader-26 connects to the internet only to:
+- Check for new versions
+- Download release metadata (latest.json)
+- Download graphics packs or mod files (when the user requests it)
+
+These requests are standard HTTPS requests made directly to GitHub or other download sources the user selects.
+
+FMMLoader-26 does not access, store, intercept, or analyze any information from these requests.
+
+GitHub may log basic connection data (like IP addresses) per their own privacy policy, which is outside of FMMLoader-26’s control.
+
+⸻
+
+4. Third-Party Services
+
+The app may interact with:
+- GitHub – for updates and asset downloads
+- Content providers – only when the user chooses to download a pack hosted elsewhere
+
+FMMLoader-26 does not share any data with these services. Users are subject to each provider’s privacy policy.
+
+⸻
+
+5. Open-Source Transparency
+
+FMMLoader-26 is fully open source.
+All behavior is visible in the source code and can be verified by any user.
+
+⸻
+
+6. Changes to This Policy
+
+If future versions introduce optional telemetry or cloud features, this policy will be updated with full transparency.
+
+⸻
+
+7. Contact
+
+For questions or concerns, please open an issue on the GitHub repository.


### PR DESCRIPTION
## Summary
- add a standalone `privacy.md` policy describing how FMMLoader-26 handles data, network requests, and third-party services

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6be8176c8329b16cd54978dd1d5b)