### PR TITLE
Update CI workflow to ignore pushes to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,10 @@
 name: CI
-
 on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
-
+    branches-ignore:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration to prevent CI jobs from running on pushes to the `main` branch, while still running on pull requests targeting `main`.
