### PR TITLE
Feature/loading state mods

### DIFF
--- a/src/components/GraphicsPackConfirmDialog.tsx
+++ b/src/components/GraphicsPackConfirmDialog.tsx
@@ -11,7 +11,7 @@
  * - Full path preview showing exact installation location
  * - Mixed pack split option to separate types into individual directories
  */
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -63,7 +63,8 @@ export function GraphicsPackConfirmDialog({
   onCancel,
   userDirPath,
 }: GraphicsPackConfirmDialogProps) {
-  const [selectedPath, setSelectedPath] = useState<string>('');
+  const defaultSuggestedPath = analysis?.suggested_paths[0] ?? '';
+  const [selectedPath, setSelectedPath] = useState<string>(defaultSuggestedPath);
   const [shouldSplit, setShouldSplit] = useState(false);
 
   const getResolvedPath = (relativePath: string): string => {
@@ -71,14 +72,9 @@ export function GraphicsPackConfirmDialog({
     return `${userDirPath}/graphics/${relativePath}`;
   };
 
-  useEffect(() => {
-    if (analysis && analysis.suggested_paths.length > 0) {
-      setSelectedPath(analysis.suggested_paths[0]);
-      setShouldSplit(false);
-    }
-  }, [analysis]);
-
   if (!analysis) return null;
+
+  const resolvedSelectedPath = selectedPath || defaultSuggestedPath;
 
   const isMixed = typeof analysis.pack_type === 'object' && 'Mixed' in analysis.pack_type;
 
@@ -130,9 +126,11 @@ export function GraphicsPackConfirmDialog({
           {/* Installation Path Selection */}
           <div className="space-y-2">
             <Label htmlFor="install-path">Install to</Label>
-            <Select value={selectedPath} onValueChange={setSelectedPath}>
+            <Select value={resolvedSelectedPath} onValueChange={setSelectedPath}>
               <SelectTrigger id="install-path">
-                <SelectValue placeholder="Select installation directory" />
+                <SelectValue placeholder="Select installation directory">
+                  {resolvedSelectedPath}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {analysis.suggested_paths.map((path) => (
@@ -144,7 +142,7 @@ export function GraphicsPackConfirmDialog({
             </Select>
             {userDirPath && (
               <p className="text-xs text-muted-foreground font-mono break-all">
-                {getResolvedPath(selectedPath)}
+                {getResolvedPath(resolvedSelectedPath)}
               </p>
             )}
           </div>
@@ -181,7 +179,10 @@ export function GraphicsPackConfirmDialog({
           <Button variant="outline" onClick={onCancel}>
             Cancel
           </Button>
-          <Button onClick={() => onConfirm(selectedPath, shouldSplit)} disabled={!selectedPath}>
+          <Button
+            onClick={() => onConfirm(resolvedSelectedPath, shouldSplit)}
+            disabled={!resolvedSelectedPath}
+          >
             Install Graphics Pack
           </Button>
         </DialogFooter>

--- a/src/hooks/useUpdater.ts
+++ b/src/hooks/useUpdater.ts
@@ -127,7 +127,7 @@ export const useUpdater = () => {
         return null;
       }
     },
-    [addLog, logToBackend]
+    [addLog, logToBackend, appVersion]
   );
 
   const downloadAndInstall = useCallback(async () => {
@@ -221,13 +221,12 @@ export const useUpdater = () => {
 
   // Check for updates on mount
   useEffect(() => {
-    addLog('Updater hook initialized');
     // Delay initial check to let the app fully load
     const timer = setTimeout(() => {
       checkForUpdates(false);
     }, 3000);
     return () => clearTimeout(timer);
-  }, [checkForUpdates, addLog]);
+  }, [checkForUpdates]);
 
   return {
     status,


### PR DESCRIPTION
This pull request significantly improves the user experience during long-running operations, especially mod and graphics pack imports, by introducing unified blocking overlays and progress indicators. It also refactors the graphics pack confirmation dialog to handle state more robustly and cleans up some minor issues in the updater hook.

**User Experience Improvements:**

* Introduced a `blockingMessage` state and a reusable `runWithBlockingMessage` helper in `App.tsx` to display a blocking overlay with a custom message during long-running mod-related actions, ensuring users are informed and preventing unintended interactions. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R98) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R150-R185)
* Replaced repeated toast notifications for graphics pack installation with a dedicated overlay showing real-time progress, phase labels, and a progress bar, providing clearer and more consistent feedback. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R1113-R1127) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R2052-R2106)
* Updated all mod and graphics pack import flows, including drag-and-drop and metadata dialog, to use the new blocking overlay mechanism for better consistency and user feedback. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R373-R380) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L409-R493) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R503-R518) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L675-R741) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R753) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R772) [[7]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L921-R977) [[8]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L934-R990)

**Graphics Pack Confirmation Dialog Enhancements:**

* Refactored `GraphicsPackConfirmDialog` to initialize and display the installation path more robustly, using a default suggested path and ensuring UI consistency if the analysis changes. [[1]](diffhunk://#diff-cd9c1cbadf2af520cc4c9530146fa839b02dcf56e9af0d7ea5075e28ca39f40bL14-R14) [[2]](diffhunk://#diff-cd9c1cbadf2af520cc4c9530146fa839b02dcf56e9af0d7ea5075e28ca39f40bL66-R78) [[3]](diffhunk://#diff-cd9c1cbadf2af520cc4c9530146fa839b02dcf56e9af0d7ea5075e28ca39f40bL133-R133) [[4]](diffhunk://#diff-cd9c1cbadf2af520cc4c9530146fa839b02dcf56e9af0d7ea5075e28ca39f40bL147-R145) [[5]](diffhunk://#diff-cd9c1cbadf2af520cc4c9530146fa839b02dcf56e9af0d7ea5075e28ca39f40bL184-R185)
* Added a `key` prop to the dialog to force a reset when the pending graphics path or analysis changes, preventing stale state.

**Updater Hook Cleanup:**

* Fixed a missing dependency in the updater hook and removed redundant logging to prevent unnecessary effect executions and log clutter. [[1]](diffhunk://#diff-f6fdab16bc50869a58dad4f6f41543dac397089ecc9de001aa667452178c5d4bL130-R130) [[2]](diffhunk://#diff-f6fdab16bc50869a58dad4f6f41543dac397089ecc9de001aa667452178c5d4bL224-R229)