### PR TITLE
Fix casing in jalco-repoAI commands

### DIFF
--- a/.github/workflows/jalco-repoAI-auto-sync.yml
+++ b/.github/workflows/jalco-repoAI-auto-sync.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Run jalco-repoAI init (idempotent)
-        run: npx jalco-repoAI init --no-sample
+      - name: Run jalco-repoai init (idempotent)
+        run: npx jalco-repoai init --no-sample
 
       - name: Sync tasks index
-        run: npx jalco-repoAI sync
+        run: npx jalco-repoai sync
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by correcting the casing of the `jalco-repoai` CLI commands to ensure consistency and prevent potential command not found errors.

* Updated all instances of the `jalco-repoAI` command to `jalco-repoai` (lowercase) in the `.github/workflows/jalco-repoAI-auto-sync.yml` workflow file to match the correct package name.