### PR TITLE
chore: bump version to 1.1.0 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fmmloader26",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "A mod manager for Football Manager 2026",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fmmloader26"
-version = "1.0.5"
+version = "1.1.0"
 description = "A mod manager for Football Manager 2026"
 authors = ["Justin Levine"]
 license = "CC-BY-NC-SA-4.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FMMLoader26",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "identifier": "com.jalco.fmmloader26",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -12,7 +12,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/icon.icns", "icons/icon.ico", "icons/icon.png"],
+    "icon": [
+      "icons/icon.icns",
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
     "resources": [],
     "externalBin": [],
     "copyright": "",


### PR DESCRIPTION
Automated version bump to 1.1.0.
- Updated package.json
- Updated src-tauri/Cargo.toml
- Updated src-tauri/tauri.conf.json