### PR TITLE
chore: use PAT for releases and trigger docs revalidation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
         id: tauri
         uses: tauri-apps/tauri-action@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
@@ -235,7 +235,7 @@ jobs:
     steps:
       - name: Generate release notes and publish
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
@@ -267,3 +267,9 @@ jobs:
             --repo "${{ github.repository }}" \
             --notes "$FULL_BODY" \
             --draft=false
+
+      - name: Trigger changelog revalidation
+        run: |
+          curl -X GET "https://www.fmmloader.com/api/revalidate" \
+            -H "Authorization: Bearer ${{ secrets.REVALIDATE_TOKEN }}" \
+            -H "Content-Type: application/json"


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with PAT_TOKEN to show user as release contributor instead of github-actions[bot]
- Add changelog revalidation step to update docs site after release

## Changes
- Updated `tauri-action` to use `PAT_TOKEN` instead of `GITHUB_TOKEN`
- Updated `finalize-release` job to use `PAT_TOKEN` for release notes
- Added step to trigger docs site revalidation via API call

## Setup Required
Requires two repository secrets to be configured:
- `PAT_TOKEN` - GitHub Personal Access Token with `repo` scope
- `REVALIDATE_TOKEN` - Docs site revalidation token

🤖 Generated with [Claude Code](https://claude.com/claude-code)