### PR TITLE
feat: add macOS code signing and notarization support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
         description: "Dry run (test version sync without building)"
         type: boolean
         default: false
+      test_build:
+        description: "Test build (build artifacts without release)"
+        type: boolean
+        default: false
       test_version:
         description: "Test version (e.g., 1.2.3) - only used in dry run"
         type: string
@@ -123,7 +127,7 @@ jobs:
 
   publish-tauri:
     needs: sync-version
-    if: inputs.dry_run != true
+    if: inputs.dry_run != true && (github.event_name == 'push' || inputs.test_build == true)
     permissions:
       contents: write
     timeout-minutes: 45
@@ -204,6 +208,20 @@ jobs:
       - name: install frontend dependencies
         run: npm ci
 
+      - name: Import code signing certificate (macOS)
+        if: matrix.platform == 'macos-15'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p actions temp.keychain
+          security default-keychain -s temp.keychain
+          security unlock-keychain -p actions temp.keychain
+          security import certificate.p12 -k temp.keychain -P $APPLE_CERTIFICATE_PASSWORD -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k actions temp.keychain
+          rm certificate.p12
+
       - name: Build & publish (tauri-action)
         id: tauri
         uses: tauri-apps/tauri-action@v0
@@ -211,11 +229,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: "FMMLoader26 ${{ github.ref_name }}"
-          releaseBody: "Building artifacts..."
-          releaseDraft: true
+          tagName: ${{ inputs.test_build == true && '' || github.ref_name }}
+          releaseName: ${{ inputs.test_build == true && '' || format('FMMLoader26 {0}', github.ref_name) }}
+          releaseBody: ${{ inputs.test_build == true && '' || 'Building artifacts...' }}
+          releaseDraft: ${{ inputs.test_build != true }}
           prerelease: false
           args: ${{ matrix.args }}
 
@@ -228,7 +249,7 @@ jobs:
 
   finalize-release:
     needs: publish-tauri
-    if: inputs.dry_run != true
+    if: inputs.dry_run != true && inputs.test_build != true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Allow JIT compilation for V8/JavaScript -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+
+  <!-- Allow unsigned executable memory (required for some operations) -->
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+
+  <!-- Disable library validation (required for Tauri) -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+
+  <!-- Network access (for updater plugin) -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+
+  <!-- File system access (for fs plugin) -->
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,8 +32,8 @@
       "frameworks": [],
       "minimumSystemVersion": "",
       "exceptionDomain": "",
-      "signingIdentity": null,
-      "entitlements": null
+      "signingIdentity": "Developer ID Application: Justin Levine (B5K625NG2X)",
+      "entitlements": "entitlements.plist"
     },
     "linux": {
       "deb": {


### PR DESCRIPTION
## Summary
- Configures Developer ID Application signing for macOS builds
- Adds entitlements for file system, network, and JIT access required by Tauri plugins
- Implements CI/CD code signing with certificate import in GitHub Actions
- Enables Apple notarization to eliminate Gatekeeper warnings
- Adds test build mode for artifact-only builds without creating releases

## Changes
- **tauri.conf.json**: Added signing identity and entitlements reference
- **entitlements.plist**: Created with required macOS entitlements
- **build.yml**: Added certificate import step and notarization environment variables
- **build.yml**: Added `test_build` input for testing builds without releases

## Testing
To test the signing without creating a release:
1. Go to Actions → Build to release
2. Click "Run workflow"
3. Check "Test build (build artifacts without release)"
4. Download the signed artifacts from the workflow run

## Dependencies
Requires the following GitHub secrets to be configured:
- `APPLE_CERTIFICATE` (base64-encoded .p12)
- `APPLE_CERTIFICATE_PASSWORD`
- `APPLE_ID`
- `APPLE_PASSWORD` (app-specific password)
- `APPLE_TEAM_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)