### PR TITLE
fix: exclude debug binary from production builds to prevent signing timeout

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,17 @@ tracing-appender = "0.2"
 hostname = "0.4"
 tokio = { version = "1", features = ["full"] }
 
+[[bin]]
+name = "fmmloader26"
+path = "src/main.rs"
+
+# Debug binary - only for local development, excluded from Tauri bundles
+[[bin]]
+name = "fmml_path_debug"
+path = "src/bin/fmml_path_debug.rs"
+required-features = ["__debug_only"]
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+__debug_only = []  # Feature flag that's never enabled in production


### PR DESCRIPTION
## Problem
The `fmml_path_debug` binary was causing macOS code signing to hang for **39+ minutes** in CI before timing out. This happened because `codesign` got stuck when trying to sign the debug binary, likely due to timeout issues communicating with Apple's timestamp server.

## Root Cause
Tauri automatically bundles all binaries in `src/bin/`, including the debug-only `fmml_path_debug.rs` utility. During the release build, this binary was being:
1. Compiled for x86_64
2. Bundled into the `.app`
3. Code signed (where it hung)

## Solution
Add a feature flag `__debug_only` that gates the debug binary compilation. The binary now requires `--features="__debug_only"` to build, which means:
- ✅ Still available for local development
- ✅ Excluded from production Tauri bundles
- ✅ No longer signed during release builds
- ✅ Prevents the 39-minute timeout issue

## Testing
```bash
# Main app still builds normally
cargo build --release --bin fmmloader26

# Debug binary requires explicit feature flag
cargo build --release --bin fmml_path_debug  # ❌ Fails  
cargo build --release --bin fmml_path_debug --features="__debug_only"  # ✅ Works
```

Fixes the code signing timeout issue discovered in workflow run #19692038918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)